### PR TITLE
Resize the Popup dimension Height by default

### DIFF
--- a/src/options/options.html
+++ b/src/options/options.html
@@ -17,7 +17,7 @@
       <div class="row">
         <label>
           <span>Popup dimensions (px)</span>
-          <input id="popupWidth" type="text" name="popupWidth"><input id="popupHeight" type="text" name="popupWidth"> (default : 900 x 600)
+          <input id="popupWidth" type="text" name="popupWidth"><input id="popupHeight" type="text" name="popupWidth"> (default : 576 x 768)
         </label>
       </div>
       <div class="row">

--- a/src/storage.js
+++ b/src/storage.js
@@ -4,8 +4,8 @@ Default settings. Initialize storage to these values.
 var storage = {
   url: '',
   pageAction: false,
-  popupWidth: 900,
-  popupHeight: 600,
+  popupWidth: 576,
+  popupHeight: 768,
 }
 
 /**


### PR DESCRIPTION
Hi;

I just made a little modification for the popup dimension, which I found it's an improvement because not everyone will go to the plugin manager to adjust the dimension then it could result they said the plugin not working simply because they are unable to save the link.

Cheer!

Jonathan