### PR TITLE
Add keyboard shortcut to share links

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,13 @@
     "default_icon": "resources/icons/icon-24.png",
     "default_title": "Share"
   },
+  "commands": {
+      "_execute_browser_action": {
+          "suggested_key": {
+              "default": "Ctrl+Alt+S"
+          }
+      }
+  },
   "page_action": {
     "browser_style": false,
     "default_icon": "resources/icons/icon-24.png",


### PR DESCRIPTION
Use Ctrl+Alt+S, which seems to be available.
